### PR TITLE
Fix `attempt to subtract with overflow` error in `get_glyph_kern_advance`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -791,7 +791,7 @@ impl<Data: Deref<Target=[u8]>> FontInfo<Data> {
         }
 
         let mut l: i32 = 0;
-        let mut r: i32 = (BE::read_u16(&kern[10..]) - 1) as i32;
+        let mut r: i32 = BE::read_u16(&kern[10..]) as i32 - 1;
         let needle = glyph_1 << 16 | glyph_2;
         while l <= r {
             let m = (l + r) >> 1;


### PR DESCRIPTION
This fixes dylanede/rusttype#30 and PistonDevelopers/conrod#874.

Here's the [equivalent line](https://github.com/nothings/stb/blob/master/stb_truetype.h#L1493) in the original C header. I wasn't 100% sure of the behaviour here, the operation basically seems to be this:

```
int a = (unsigned short)b - (int)c
```

After reading [this SO post](http://stackoverflow.com/a/15030332/1711917), it seems like b is converted to the result type `int` before the subtraction operation takes place? This even seems to be the case when doing `int = (unsigned int) - (unsigned int);`.

Anyways, I believe this PR changes the behaviour to more accurately represent the original C code behaviour and does seem to fix the bug when testing the aforementioned downstream issues.