### PR TITLE
fix: out of bounds read for empty font data

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -155,8 +155,12 @@ enum MacLang { // languageID for PLATFORM_ID_MAC
 // truetype fonts that aren't padded to alignment, define ALLOW_UNALIGNED_TRUETYPE
 
 pub fn is_font(font: &[u8]) -> bool {
-    let tag = &font[0..4];
-    tag == [b'1', 0, 0, 0] || tag == b"typ1" || tag == b"OTTO" || tag == [0, 1, 0, 0]
+    if font.len() >= 4 {
+        let tag = &font[0..4];
+        tag == [b'1', 0, 0, 0] || tag == b"typ1" || tag == b"OTTO" || tag == [0, 1, 0, 0]
+    } else {
+        false
+    }
 }
 
 fn find_table(data: &[u8], fontstart: usize, tag: &[u8]) -> u32 {

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -1,0 +1,11 @@
+extern crate stb_truetype;
+
+mod tests {
+    use stb_truetype;
+
+    #[test]
+    fn is_font() {
+        assert!(stb_truetype::is_font(b"OTTO"));
+        assert!(!stb_truetype::is_font(b""));
+    }
+}


### PR DESCRIPTION
- if the &[u8] for the font is < 4 bytes, is_font() panics with out of bounds access
- add a length check and return false if the font &[u8] is too short