### PR TITLE
(Bug) Removed wrong width == height check and removed debug statement

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -385,24 +385,16 @@ impl<Data: Deref<Target=[u8]>> FontInfo<Data> {
     }
 
     fn get_glyf_offset(&self, glyph_index: u32) -> Option<u32> {
-        let g1;
-        let g2;
+
         if glyph_index >= self.num_glyphs || self.index_to_loc_format >= 2 {
             // glyph index out of range or unknown index->glyph map format
             return None;
         }
 
         if self.index_to_loc_format == 0 {
-            g1 = self.glyf + BE::read_u16(&self.data[(self.loca + glyph_index*2) as usize..]) as u32 * 2;
-            g2 = self.glyf + BE::read_u16(&self.data[(self.loca + glyph_index*2 + 2) as usize..]) as u32 * 2;
+            Some(self.glyf + BE::read_u16(&self.data[(self.loca + glyph_index*2) as usize..]) as u32 * 2)
         } else {
-            g1 = self.glyf + BE::read_u32(&self.data[(self.loca + glyph_index * 4) as usize..]);
-            g2 = self.glyf + BE::read_u32(&self.data[(self.loca + glyph_index * 4 + 4) as usize..]);
-        }
-        if g1 == g2 {
-            None
-        } else {
-            Some(g1)
+            Some(self.glyf + BE::read_u32(&self.data[(self.loca + glyph_index * 4) as usize..]))
         }
     }
 
@@ -533,9 +525,6 @@ impl<Data: Deref<Target=[u8]>> FontInfo<Data> {
             let mut x = 0i32;
             for i in 0..n {
                 let flags = vertices[off + i].type_;
-                if flags == 255 {
-                    println!("{:?}", flags);
-                }
                 if flags & 2 != 0 {
                     let dx = points[0] as i32;
                     points = &points[1..];


### PR DESCRIPTION
This is a bug that I noticed here: https://github.com/dylanede/rusttype/issues/47

What the old code is doing is nonsense - it reads the `numberOfContours` from the glyf table and the first two bytes of the `xMin` coordinate. If they are not equal (most cases), it returns the offset of the glyf in the file. In the case of the space character (U+0020) the number of contours is 0, and the x coordinate is -10, which in big endian means that the first two bytes are 0, too. So I couldn't get the width of the character.

At least that is what I get from the Microsoft documentation about TrueType fonts:

| Type  | Name             | Description                                                                                                                 |
|-------|------------------|-----------------------------------------------------------------------------------------------------------------------------|
| SHORT | numberOfContours | If,the number of contours is greater than or equal to zero, this is a single glyph; if negative, this is a composite glyph. |
| FWord | xMin             | Minimum x for coordinate data.                                                                                              |
| FWord | yMin             | Minimum y for coordinate data.                                                                                              |
| FWord | xMax             | Maximum x for coordinate data.                                                                                              |
| FWord | yMax             | Maximum y for coordinate data.                                                                                              |
