### PR TITLE
Added units_per_em function

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -958,12 +958,16 @@ impl<Data: Deref<Target=[u8]>> FontInfo<Data> {
         height / fheight
     }
 
+    /// Returns the units per EM square of this font.
+    pub fn units_per_em(&self) -> u16 {
+        BE::read_u16(&self.data[self.head as usize + 18..])
+    }
+
     /// computes a scale factor to produce a font whose EM size is mapped to
     /// `pixels` tall. This is probably what traditional APIs compute, but
     /// I'm not positive.
     pub fn scale_for_mapping_em_to_pixels(&self, pixels: f32) -> f32 {
-        let units_per_em = BE::read_u16(&self.data[self.head as usize + 18..]) as f32;
-        pixels / units_per_em
+        pixels / (self.units_per_em() as f32)
     }
 
     /// like `get_codepoint_bitmap_box_subpixel`, but takes a glyph index instead of a codepoint.


### PR DESCRIPTION
See https://github.com/redox-os/rusttype/issues/79 - this exposes the "units per EM height" of a font - usually a value of 1024 or 2048. I've checked that these are the correct values by cross-referencing freetype. The returned value is the same as in freetype the [FTFaceRect::units_per_EM](https://www.freetype.org/freetype2/docs/reference/ft2-base_interface.html#units_per_EM) value.