### PR TITLE
codepoint_iter() for iterating through the codepoints supplied by a font

### DIFF
--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -21,4 +21,8 @@ fn main() {
     println!("{:?}", advance);
     let scale = font.scale_for_pixel_height(20.0);
     println!("{:?}", scale);
+    print!("Codepoints: ");
+    for cp in font.codepoint_iter() {
+        print!("{:X},",cp);
+    }
 }


### PR DESCRIPTION
I have need to iterate through the codepoints in a font (to make font atlases for a game).  So I created a codepoint iterator that works for some (the most common?) ttf formats.  I think the original stb_truetype.h file probably has a query API that looks different, I wrote this one from scratch based on the Microsoft page https://docs.microsoft.com/en-us/typography/opentype/spec/cmap#format-4-segment-mapping-to-delta-values. Only tested for format 4.